### PR TITLE
feat: remove version number from package.json

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -42,8 +42,3 @@ jobs:
           pnpm publish .
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-
-      - name: Update the package version number
-        run: git push
-        env:
-          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,5 @@
 {
   "name": "@aligent/ts-code-standards",
-  "version": "1.2.0",
   "main": "src/index.js",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Removes the version number from package.json to avoid confusion. Instead, it will be added during a release when publishing to npm.