### PR TITLE
TCS-2: Tidy up after GitHub migration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,11 @@ updates:
     schedule:
       interval: 'monthly'
     open-pull-requests-limit: 10
+    groups:
+      minor-and-patch:
+        applies-to: version-updates
+        patterns:
+          - '*'
+        update-types:
+          - "minor"
+          - "patch"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,8 @@ updates:
     schedule:
       interval: 'monthly'
     open-pull-requests-limit: 10
+    commit-message:
+      prefix: "TCS-3"
     groups:
       minor-and-patch:
         applies-to: version-updates

--- a/README.md
+++ b/README.md
@@ -4,11 +4,6 @@ Standard code quality tooling for projects written in TypeScript.
 
 ## Usage
 
-Set up your package manager to use Aligent's private NPM registry:
-
-- Go to `https://npm.corp.aligent.consulting` and log in.
-- Click the Gear icon to get instructions for configuring your package manager.
-
 Install this module:
 
     # NPM

--- a/package.json
+++ b/package.json
@@ -26,12 +26,5 @@
     "prettier": "^3.3.3",
     "typescript": "^5.6.3"
   },
-  "pnpm": {
-    "peerDependencyRules": {
-      "allowedVersions": {
-        "eslint": "^9"
-      }
-    }
-  },
   "packageManager": "pnpm@9.12.2+sha512.22721b3a11f81661ae1ec68ce1a7b879425a1ca5b991c975b074ac220b187ce56c708fe5db69f4c962c989452eee76c82877f4ee80f474cebd61ee13461b6228"
 }


### PR DESCRIPTION
- Have dependabot use a ticket number in it's commits and PRs
- Group minor and patch versions into a single PR to reduce noise
- Remove references to our private repo in the README
- Remove a no-longer-necessary peer dependency workaround