### PR TITLE
TCS-4: Swap import sorting from eslint to prettier to allow auto-sorting

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "eslint-plugin-prettier": "^5.2.1",
     "eslint-plugin-react": "^7.37.3",
     "eslint-plugin-react-hooks": "^5.1.0",
+    "prettier-plugin-organize-imports": "^4.1.0",
     "prettier-plugin-tailwindcss": "^0.6.9",
     "typescript-eslint": "^8.19.0"
   },
@@ -35,7 +36,6 @@
     "@types/eslint__js": "^8.42.3",
     "eslint": "^9.17.0",
     "prettier": "^3.4.1",
-    "prettier-plugin-organize-imports": "^4.1.0",
     "rollup": "^4.29.1",
     "typescript": "^5.7.2"
   },

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "@types/eslint__js": "^8.42.3",
     "eslint": "^9.17.0",
     "prettier": "^3.4.1",
+    "prettier-plugin-organize-imports": "^4.1.0",
     "rollup": "^4.29.1",
     "typescript": "^5.7.2"
   },

--- a/src/index.js
+++ b/src/index.js
@@ -1,9 +1,9 @@
-import eslint from '@eslint/js';
-import eslintPluginPrettier from 'eslint-plugin-prettier/recommended';
 import { fixupPluginRules } from '@eslint/compat';
-import hooksPlugin from 'eslint-plugin-react-hooks';
+import eslint from '@eslint/js';
 import jsxA11yPlugin from 'eslint-plugin-jsx-a11y';
+import eslintPluginPrettier from 'eslint-plugin-prettier/recommended';
 import reactPlugin from 'eslint-plugin-react';
+import hooksPlugin from 'eslint-plugin-react-hooks';
 import tsEslint from 'typescript-eslint';
 
 const core = [

--- a/src/index.js
+++ b/src/index.js
@@ -20,7 +20,7 @@ const core = [
                         'Do not use TypeScript enums. Please use const enums instead. See: https://dev.to/ivanzm123/dont-use-enums-in-typescript-they-are-very-dangerous-57bh for details.',
                 },
             ],
-            'sort-imports': ['error'],
+            'sort-imports': ['off'],
             '@typescript-eslint/ban-ts-comment': [
                 'error',
                 {
@@ -61,5 +61,5 @@ export const prettierConfig = {
     arrowParens: 'avoid',
     singleQuote: true,
     trailingComma: 'es5',
-    plugins: ['prettier-plugin-tailwindcss'],
+    plugins: ['prettier-plugin-tailwindcss', 'prettier-plugin-organize-imports'],
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -20,6 +20,7 @@ __metadata:
     eslint-plugin-react: "npm:^7.37.3"
     eslint-plugin-react-hooks: "npm:^5.1.0"
     prettier: "npm:^3.4.1"
+    prettier-plugin-organize-imports: "npm:^4.1.0"
     prettier-plugin-tailwindcss: "npm:^0.6.9"
     rollup: "npm:^4.29.1"
     typescript: "npm:^5.7.2"
@@ -3009,6 +3010,20 @@ __metadata:
   dependencies:
     fast-diff: "npm:^1.1.2"
   checksum: 10c0/81e0027d731b7b3697ccd2129470ed9913ecb111e4ec175a12f0fcfab0096516373bf0af2fef132af50cafb0a905b74ff57996d615f59512bb9ac7378fcc64ab
+  languageName: node
+  linkType: hard
+
+"prettier-plugin-organize-imports@npm:^4.1.0":
+  version: 4.1.0
+  resolution: "prettier-plugin-organize-imports@npm:4.1.0"
+  peerDependencies:
+    prettier: ">=2.0"
+    typescript: ">=2.9"
+    vue-tsc: ^2.1.0
+  peerDependenciesMeta:
+    vue-tsc:
+      optional: true
+  checksum: 10c0/fb2d6d415bac96b65a77ea7de9f708e8613436aeb9d82bbe63edeb312fd1362c0d3c57319bd4cc4adfc8b9964fb6c205cbbf8efd9546931b0f9874c0ae624a6a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Solves the issue of imports failing linting but not being able to be auto-sorted, requiring devs to manually re-order their imports.

I would suggest that this might be a breaking change, as it will cause most projects it is used in to fail linting as the prettier sorting is different to the eslint sorting.