### PR TITLE
TCS-5 Add array type rule

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -32,6 +32,12 @@ const core = [
                 'error',
                 { argsIgnorePattern: '^_', ignoreRestSiblings: true },
             ],
+            '@typescript-eslint/array-type': [
+                'error',
+                {
+                    default: 'array-simple',
+                },
+            ],
         },
     },
 ];


### PR DESCRIPTION
Add the [array-type][] rule to our default linting config.

Discussion of the best way to express arrays happens quite frequently, and the outcome is always "it doesn't matter". Pick a sensible default to avoid the discussion in code reviews.

[array-type]: https://typescript-eslint.io/rules/array-type/