### PR TITLE
bugfix: Publish .editorconfig file to npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
   },
   "files": [
     "dist",
-    "tsconfigs"
+    "tsconfigs",
+    ".editorconfig"
   ],
   "scripts": {
     "test": "tsc && eslint .",


### PR DESCRIPTION
This will include `.editorconfig` in the node_modules folder when the package is installed from npm. The instructions in the README will work..