### PR TITLE
chore: Adding standard contributing and code of conduct docs

### DIFF
--- a/docs/CODE_OF_CONDUCT.md
+++ b/docs/CODE_OF_CONDUCT.md
@@ -1,0 +1,3 @@
+# Code of Conduct
+
+Please refer to the main [Aligent Code of Conduct](https://github.com/aligent/code-of-conduct/blob/main/CODE_OF_CONDUCT.md).

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,0 +1,3 @@
+# Contributing
+
+Please refer to the main [Aligent Contribution Guide](https://github.com/aligent/code-of-conduct/blob/main/CONTRIBUTING.md).


### PR DESCRIPTION
Linking to our main contributing/CoC repo.

Main question from me is if we want them in the root directory or under `./docs`, which I copied from the graphql mesh repo.