### PR TITLE
TCS-8 Add Report used ignore pattern

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -30,7 +30,11 @@ const core = [
             'array-callback-return': ['error', { checkForEach: true }],
             '@typescript-eslint/no-unused-vars': [
                 'error',
-                { argsIgnorePattern: '^_', ignoreRestSiblings: true },
+                {
+                    argsIgnorePattern: '^_',
+                    ignoreRestSiblings: true,
+                    reportUsedIgnorePattern: true,
+                },
             ],
             '@typescript-eslint/array-type': [
                 'error',


### PR DESCRIPTION
Add the option `reportUsedIgnorePattern` to the ESlint config. This will prevent accidentally prefixing variables with `_` when they shouldn't be.