### PR TITLE
Add microservices team to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,6 @@
-.github/* @aligent/aligent-devops
+# DevOps team owns the .github folder
+.github/ @aligent/devops
 
+# Frontend and Microservices teams own everything else
 * @aligent/frontends
 * @aligent/microservices

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,4 @@
 .github/* @aligent/aligent-devops
 
 * @aligent/frontends
+* @aligent/microservices


### PR DESCRIPTION
We're using this in all microservices projects as well, makes sense for the team to be codeowners.