### PR TITLE
TF2-401 Load Tailwind plugin last

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -82,5 +82,5 @@ export const prettierConfig = {
     arrowParens: 'avoid',
     singleQuote: true,
     trailingComma: 'es5',
-    plugins: ['prettier-plugin-tailwindcss', 'prettier-plugin-organize-imports'],
+    plugins: ['prettier-plugin-organize-imports', 'prettier-plugin-tailwindcss'],
 };


### PR DESCRIPTION
Fix up an issue where Tailwind prettier plugin isn't working.

I missed [this detail] from the documentation.

[this detail]: https://github.com/tailwindlabs/prettier-plugin-tailwindcss/blob/main/README.md?plain=1#L227