### PR TITLE
fixes typo instruction for tsconfig.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Standard code quality tooling for projects written in TypeScript.
 ##### Add the following to your `tsconfig.json`:
 
 ```json
-{ "extends": "@aligent/ts-code-standards/tsconfigs-base" }
+{ "extends": "@aligent/ts-code-standards/tsconfigs/base.json" }
 ```
 
 #### React Projects


### PR DESCRIPTION
As per confirmation with Sam, the related directory just needed correction in the README.md instruction.