### PR TITLE
TCS-10: Enforce import type via consistent-type-imports

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -44,6 +44,19 @@ const base = [
             ],
         },
     },
+    {
+        files: ['**/*.{ts,tsx,js,jsx,mjs,cjs}'],
+        rules: {
+            '@typescript-eslint/consistent-type-imports': [
+                'error',
+                {
+                    prefer: 'type-imports',
+                    fixStyle: 'separate-type-imports',
+                    disallowTypeAnnotations: true,
+                },
+            ],
+        },
+    },
 ];
 
 const react = [


### PR DESCRIPTION
**Description of the proposed changes**
Enforce `import type` for type-only imports across consuming projects by adding `@typescript-eslint/consistent-type-imports` to the shared base ESLint config.

- Type-only imports were previously written as regular imports → now flagged as errors and auto-fixed to `import type { ... }`.

  ```ts
  // Before
  import { Cart } from './types';
  let cart: Cart;

  // After
  import type { Cart } from './types';
  let cart: Cart;
  ```

- Mixed runtime/type imports were previously a single statement → now split into separate runtime and `import type` statements (`fixStyle: 'separate-type-imports'`).

  ```ts
  // Before
  import { createCart, Cart } from './cart';
  const c: Cart = createCart();

  // After
  import { createCart } from './cart';
  import type { Cart } from './cart';
  const c: Cart = createCart();
  ```

- Inline `import('...').Foo` type annotations were previously permitted → now disallowed (`disallowTypeAnnotations: true`).

  ```ts
  // Before
  let handler: import('./types').Handler;
  function render(c: import('react').FC<Props>) {}

  // After
  import type { FC } from 'react';
  import type { Handler } from './types';
  let handler: Handler;
  function render(c: FC<Props>) {}
  ```

- The rule lives in its own config object scoped to `**/*.{ts,tsx,js,jsx,mjs,cjs}` so it doesn't load against non-JS/TS files (e.g. GraphQL virtual documents extracted by `@graphql-eslint/parser`), which lack the TS parser services this rule requires.


**Screenshots (if applicable)**
Symlinked and tested on take-flight repo
<img width="1788" height="972" alt="image" src="https://github.com/user-attachments/assets/f94de60b-44c7-4bbb-91c8-ae4fbaa4ff3f" />


**Other solutions considered (if any)**

**Notes to PR author**

⚠️ Please make sure the changes adhere to the guidelines mentioned in our [contribution guide](https://github.com/aligent/code-of-conduct/blob/main/CONTRIBUTING.md).

**Notes to reviewers**

ℹ️ When you've finished leaving feedback, please add a final comment to the PR tagging the author, letting them know that you have finished leaving feedback

